### PR TITLE
Added RCT_EXPORT_MODULE() at line 23

### DIFF
--- a/DDPClient.m
+++ b/DDPClient.m
@@ -20,6 +20,8 @@
 
 @synthesize bridge = _bridge;
 
+RCT_EXPORT_MODULE();
+
 - (void)connectWithURL:(NSString *)URLString {
   RCT_EXPORT();
   self.meteorClient = [[MeteorClient alloc] initWithDDPVersion:@"1"];


### PR DESCRIPTION
Xcode version 6.4 displays a "Class DDPClient was not exported" error at run time. Recommended fix was adding in RCT_EXPORT_MODULE(). This resolves the error.
![screen shot 2015-04-14 at 10 08 56 pm](https://cloud.githubusercontent.com/assets/3388380/7152586/8fa7562e-e2f3-11e4-9d76-476e953f7d7f.png)
